### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/related-queries/index.html
+++ b/src/related-queries/index.html
@@ -1,5 +1,5 @@
 <yield>
-  <gb-list items="{ state.relatedQueries }">
-    <gb-link on-click="{ item.onClick }" _consumes="item">{ $item.value }</gb-link>
+  <gb-list items="{state.relatedQueries}">
+    <gb-link on-click="{item.onClick}" _consumes="item">{$item.value}</gb-link>
   </gb-list>
 </yield>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.